### PR TITLE
Permit `expires_in` param when creating passwordless session

### DIFF
--- a/lib/workos/passwordless/passwordless.ex
+++ b/lib/workos/passwordless/passwordless.ex
@@ -36,7 +36,7 @@ defmodule WorkOS.Passwordless do
   def create_session(params, opts)
       when is_map_key(params, :email) or is_map_key(params, :connection) do
     query =
-      process_params(params, [:email, :connection, :redirect_uri, :state, :type], %{
+      process_params(params, [:email, :connection, :redirect_uri, :state, :type, :expires_in], %{
         type: "MagicLink"
       })
 


### PR DESCRIPTION
<img width="614" alt="image" src="https://github.com/workos/workos-elixir/assets/12185627/8510a8e8-837f-4845-b2f1-94aa25a9071b">

The [`expires_in` parameter](https://workos.com/docs/reference/magic-link/passwordless-session/create) is being quietly dropped.