### PR TITLE
Add package version to `ISSUE_TEMPLATE.MD`

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -2,6 +2,7 @@
 
 * Elixir version (elixir -v):
 * Erlang/OTP version (erl):
+* Package version:
 
 ### Description
 


### PR DESCRIPTION
Adds package version to `ISSUE_TEMPLATE.MD` in order to know which package version should someone use to reproduce a 🐛 