### PR TITLE
Bump version to `0.4.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add this package to the list of dependencies in your `mix.exs` file:
 
 ```ex
 def deps do
-  [{:workos, "~> 0.3.0"}]
+  [{:workos, "~> 0.4.0"}]
 end
 ```
 The hex package can be found here: https://hex.pm/packages/workos

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule WorkOS.MixProject do
   use Mix.Project
 
-  @version "0.3.0"
+  @version "0.4.0"
   @source_url "https://github.com/workos/workos-elixir"
 
   def project do


### PR DESCRIPTION
I've published a patch version to [Hex](https://hex.pm/packages/workos) with the [latest bug fix](https://github.com/workos/workos-elixir/pull/35) merged to the `main` branch. 