### PR TITLE
Add groups to directory sync user struct

### DIFF
--- a/lib/workos/directory_sync/directory/user.ex
+++ b/lib/workos/directory_sync/directory/user.ex
@@ -19,6 +19,7 @@ defmodule WorkOS.DirectorySync.Directory.User do
           last_name: String.t(),
           job_title: String.t() | nil,
           state: String.t(),
+          groups: [%WorkOS.DirectorySync.Directory.Group{}],
           updated_at: String.t(),
           created_at: String.t()
         }
@@ -30,10 +31,11 @@ defmodule WorkOS.DirectorySync.Directory.User do
     :raw_attributes,
     :custom_attributes,
     :idp_id,
-    :first_name,
     :emails,
     :username,
+    :first_name,
     :last_name,
+    :groups,
     :state,
     :updated_at,
     :created_at
@@ -46,11 +48,12 @@ defmodule WorkOS.DirectorySync.Directory.User do
     :raw_attributes,
     :custom_attributes,
     :idp_id,
-    :first_name,
     :emails,
     :username,
+    :first_name,
     :last_name,
     :job_title,
+    :groups,
     :state,
     :updated_at,
     :created_at
@@ -66,11 +69,12 @@ defmodule WorkOS.DirectorySync.Directory.User do
       custom_attributes: map["custom_attributes"],
       directory_id: map["directory_id"],
       idp_id: map["idp_id"],
-      first_name: map["first_name"],
       emails: map["emails"],
       username: map["username"],
+      first_name: map["first_name"],
       last_name: map["last_name"],
       job_title: map["job_title"],
+      groups: WorkOS.Castable.cast_list(WorkOS.DirectorySync.Directory.Group, map["groups"]),
       state: map["state"],
       updated_at: map["updated_at"],
       created_at: map["created_at"]


### PR DESCRIPTION
In looking through the [WorkOS API docs](https://workos.com/docs/reference/directory-sync/directory-user/get), I noticed the response for directory sync users included groups nested within the user data.  When attempting to use the workos-elixir package I ran in to an issue where I needed the group information for a user, however it wasn't part of the user struct.

This PR adds the groups info to the directory sync user struct.

Thank you for considering this PR and please let me know if I need to change/add anything.