### PR TITLE
Add OAuth token to WorkOS.UserManagement.Authentication struct

### DIFF
--- a/lib/workos/user_management/authentication.ex
+++ b/lib/workos/user_management/authentication.ex
@@ -9,22 +9,35 @@ defmodule WorkOS.UserManagement.Authentication do
 
   @type t() :: %__MODULE__{
           user: User.t(),
-          organization_id: String.t() | nil
+          organization_id: String.t() | nil,
+          access_token: String.t() | nil,
+          refresh_token: String.t() | nil,
+          impersonator: User.t() | nil,
+          authentication_method: String.t()
         }
 
   @enforce_keys [
-    :user
+    :user,
+    :authentication_method
   ]
   defstruct [
     :user,
-    :organization_id
+    :organization_id,
+    :access_token,
+    :refresh_token,
+    :impersonator,
+    :authentication_method
   ]
 
   @impl true
   def cast(map) do
     %__MODULE__{
       user: map["user"],
-      organization_id: map["organization_id"]
+      organization_id: map["organization_id"],
+      access_token: map["access_token"],
+      refresh_token: map["refresh_token"],
+      impersonator: map["impersonator"],
+      authentication_method: map["authentication_method"]
     }
   end
 end

--- a/test/support/user_management_client_mock.ex
+++ b/test/support/user_management_client_mock.ex
@@ -64,6 +64,14 @@ defmodule WorkOS.UserManagement.ClientMock do
     "organization_id" => "organization_01H5JQDV7R7ATEYZDEG0W5PRYS"
   }
 
+  @authentication_code_mock %{
+    "user" => @user_mock,
+    "organization_id" => "organization_01H5JQDV7R7ATEYZDEG0W5PRYS",
+    "access_token" => "01DMEK0J53CVMC32CK5SE0KZ8Q",
+    "refresh_token" => "01DMEK0J53CVMC32CK5SE0KZ8Q",
+    "authentication_method" => "SSO"
+  }
+
   def get_user(context, opts \\ []) do
     Tesla.Mock.mock(fn request ->
       %{api_key: api_key} = context
@@ -183,12 +191,15 @@ defmodule WorkOS.UserManagement.ClientMock do
 
       body = Jason.decode!(request.body)
 
-      for {field, value} <-
-            Keyword.get(opts, :assert_fields, []) do
+      for {field, value} <- Keyword.get(opts, :assert_fields, []) do
         assert body[to_string(field)] == value
       end
 
-      success_body = @authentication_mock
+      success_body =
+        case body do
+          %{"code" => _} -> @authentication_code_mock
+          _ -> @authentication_mock
+        end
 
       {status, body} = Keyword.get(opts, :respond_with, {200, success_body})
       %Tesla.Env{status: status, body: body}

--- a/test/workos/user_management_test.exs
+++ b/test/workos/user_management_test.exs
@@ -225,10 +225,12 @@ defmodule WorkOS.UserManagementTest do
 
       context |> ClientMock.authenticate(assert_fields: opts)
 
-      assert {:ok, %WorkOS.UserManagement.Authentication{user: user}} =
+      assert {:ok, auth = %WorkOS.UserManagement.Authentication{}} =
                WorkOS.UserManagement.authenticate_with_code(opts |> Enum.into(%{}))
 
-      refute is_nil(user["id"])
+      refute is_nil(auth.user["id"])
+      refute is_nil(auth.access_token)
+      refute is_nil(auth.refresh_token)
     end
   end
 


### PR DESCRIPTION
Logging in a user with a code returns an OAuth access token and refresh token in the API response. Currently these tokens are discarded when casting the Authentication struct - which also means the claims from the JWT are lost.