### PR TITLE
Update WorkOS Dependency Version in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add this package to the list of dependencies in your `mix.exs` file:
 
 ```ex
 def deps do
-  [{:workos, "~> 1.0.0"}]
+  [{:workos, "~> 1.1.0"}]
 end
 ```
 


### PR DESCRIPTION
Updates the WorkOS Dependency version in the readme for the `mix.exs` change.