### PR TITLE
Update deprecated runner in GHA workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Continuous Integration
 on:
   push:
     branches:
-      - master
+      - main
       - release/**
 
   pull_request:
@@ -15,7 +15,7 @@ jobs:
   test:
     name: Test (Elixir ${{ matrix.elixir }}, OTP ${{ matrix.otp }})
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         # https://hexdocs.pm/elixir/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp


### PR DESCRIPTION
ubuntu-20.04 is fully deprecated by GitHub and can no longer be used: https://github.com/actions/runner-images/issues/11101