### PR TITLE
Use looser version requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add this package to the list of dependencies in your `mix.exs` file:
 
 ```ex
 def deps do
-  [{:workos, "~> 1.1.0"}]
+  [{:workos, "~> 1.1"}]
 end
 ```
 
@@ -28,9 +28,9 @@ config :workos, WorkOS.Client,
       client_id: "client_123456789"
 ```
 
-The only required config option is `:api_key` and `:client_id`. 
+The only required config option is `:api_key` and `:client_id`.
 
-By default, this library uses [Tesla](https://github.com/elixir-tesla/tesla) but it can be replaced via the `:client` option, according to the `WorkOS.Client` module behavior. 
+By default, this library uses [Tesla](https://github.com/elixir-tesla/tesla) but it can be replaced via the `:client` option, according to the `WorkOS.Client` module behavior.
 
 ###
 


### PR DESCRIPTION
This version will pin just the major version and match anything with a minor version of `1` or greater (any all patch numbers), instead of needing to bump it on every minor release.