### PR TITLE
Fix `UserManagement.get_authorization_url` generated url

### DIFF
--- a/lib/workos/user_management.ex
+++ b/lib/workos/user_management.ex
@@ -64,7 +64,7 @@ defmodule WorkOS.UserManagement do
       )
       |> URI.encode_query()
 
-    {:ok, "#{WorkOS.base_url()}/sso/authorize?#{query}"}
+    {:ok, "#{WorkOS.base_url()}/user_management/authorize?#{query}"}
   end
 
   def get_authorization_url(_params),


### PR DESCRIPTION
## Description

- Update `UserManagement.get_authorization_url` to generate authorization urls with `/user_management/authorize`

AuthKit authorization urls should go through `/user_management/authorize`. Standalone SSO authorization urls should go through `/sso/authorize`.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
