### PR TITLE
feat: Add lint-pr-title workflow

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,24 @@
+name: Lint PR Title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.SDK_BOT_APP_ID }}
+          private-key: ${{ secrets.SDK_BOT_PRIVATE_KEY }}
+
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
## Summary
- Add `lint-pr-title.yml` workflow using [`amannn/action-semantic-pull-request@v5`](https://github.com/amannn/action-semantic-pull-request) to enforce conventional commit PR titles
- Uses the SDK bot app token (`generate_sdk_bot_token`) for authentication, consistent with the `release-please` workflow
- Mirrors the same workflow added to [`workos-ruby`](https://github.com/workos/workos-ruby/pull/435)

## Test plan
- [ ] Open a PR with a non-conventional title (e.g. "update stuff") and verify the check fails
- [ ] Open a PR with a conventional title (e.g. "feat: Add new feature") and verify the check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)