### PR TITLE
feat: Add lint-pr-title workflow

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,24 @@
+name: Lint PR Title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.SDK_BOT_APP_ID }}
+          private-key: ${{ secrets.SDK_BOT_PRIVATE_KEY }}
+
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
## Summary
- Adds a `lint-pr-title` workflow using [`amannn/action-semantic-pull-request`](https://github.com/amannn/action-semantic-pull-request) to enforce conventional commit format on PR titles
- Uses the SDK bot app token (via `actions/create-github-app-token`) for authentication, consistent with the `release-please` workflow
- This ensures PR titles follow the conventional commits spec, which is required for release-please to generate correct changelogs and version bumps

## Test plan
- [ ] Open a PR with a non-conventional title (e.g., "update something") and verify the check fails
- [ ] Open a PR with a valid conventional title (e.g., "feat: add feature") and verify the check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)