### PR TITLE
Feat: add external_id support to create/update operations for Organization

### DIFF
--- a/lib/workos/organizations.ex
+++ b/lib/workos/organizations.ex
@@ -98,8 +98,9 @@ defmodule WorkOS.Organizations do
     * `:domain_data` - A list of maps containing domain information composed of the following:
       * `:domain` - The domain of the Organization
       * `:state` - The verification state of the domain. "pending" | "verified"
-    * `:allow_profiles_outside_organization` - Whether the Connections within this Organization should allow Profiles that do not have a domain that is present in the set of the Organization’s User Email Domains.
+    * `:allow_profiles_outside_organization` - Whether the Connections within this Organization should allow Profiles that do not have a domain that is present in the set of the Organization's User Email Domains.
     * `:idempotency_key` - A unique string as the value. Each subsequent request matching this unique string will return the same response.
+    * `:external_id` - A unique, external identifier for the Organization.
 
   """
   @spec create_organization(map()) :: WorkOS.Client.response(Organization.t())
@@ -113,7 +114,8 @@ defmodule WorkOS.Organizations do
       %{
         name: opts[:name],
         domain_data: opts[:domain_data],
-        allow_profiles_outside_organization: opts[:allow_profiles_outside_organization]
+        allow_profiles_outside_organization: opts[:allow_profiles_outside_organization],
+        external_id: opts[:external_id]
       },
       headers: [
         {"Idempotency-Key", opts[:idempotency_key]}
@@ -131,7 +133,8 @@ defmodule WorkOS.Organizations do
     * `:domain_data` - A list of maps containing domain information composed of the following:
       * `:domain` - The domain of the Organization
       * `:state` - The verification state of the domain. "pending" | "verified"
-    * `:allow_profiles_outside_organization` - Whether the Connections within this Organization should allow Profiles that do not have a domain that is present in the set of the Organization’s User Email Domains.
+    * `:allow_profiles_outside_organization` - Whether the Connections within this Organization should allow Profiles that do not have a domain that is present in the set of the Organization's User Email Domains.
+    * `:external_id` - A unique, external identifier for the Organization.
 
   """
   @spec update_organization(String.t(), map()) :: WorkOS.Client.response(Organization.t())
@@ -142,7 +145,8 @@ defmodule WorkOS.Organizations do
     WorkOS.Client.put(client, Organization, "/organizations/#{organization_id}", %{
       name: opts[:name],
       domain_data: opts[:domain_data],
-      allow_profiles_outside_organization: !!opts[:allow_profiles_outside_organization]
+      allow_profiles_outside_organization: !!opts[:allow_profiles_outside_organization],
+      external_id: opts[:external_id]
     })
   end
 end

--- a/test/support/organizations_client_mock.ex
+++ b/test/support/organizations_client_mock.ex
@@ -162,6 +162,7 @@ defmodule WorkOS.Organizations.ClientMock do
         "object" => "organization",
         "name" => body[:name],
         "allow_profiles_outside_organization" => false,
+        "external_id" => body["external_id"],
         "domains" => [
           %{
             "domain" => "example.com",
@@ -201,6 +202,7 @@ defmodule WorkOS.Organizations.ClientMock do
         "object" => "organization",
         "name" => body[:name],
         "allow_profiles_outside_organization" => false,
+        "external_id" => body["external_id"],
         "domains" => [
           %{
             "domain" => "example.com",

--- a/test/workos/organizations_test.exs
+++ b/test/workos/organizations_test.exs
@@ -100,6 +100,22 @@ defmodule WorkOS.OrganizationsTest do
 
       refute is_nil(id)
     end
+
+    test "with external_id, creates an organization with external_id", context do
+      opts = [
+        domain_data: [%{"domain" => "example.com", "state" => "pending"}],
+        name: "Test Organization",
+        external_id: "ext_org_123"
+      ]
+
+      context |> ClientMock.create_organization(assert_fields: opts)
+
+      assert {:ok, %WorkOS.Organizations.Organization{id: id, external_id: external_id}} =
+               WorkOS.Organizations.create_organization(opts |> Enum.into(%{}))
+
+      refute is_nil(id)
+      assert external_id == "ext_org_123"
+    end
   end
 
   describe "update_organization" do
@@ -119,6 +135,26 @@ defmodule WorkOS.OrganizationsTest do
                )
 
       refute is_nil(id)
+    end
+
+    test "with external_id, updates an organization with external_id", context do
+      opts = [
+        organization_id: "org_01EHT88Z8J8795GZNQ4ZP1J81T",
+        domain_data: [%{"domain" => "example.com", "state" => "pending"}],
+        name: "Test Organization 2",
+        external_id: "ext_org_456"
+      ]
+
+      context |> ClientMock.update_organization(assert_fields: opts)
+
+      assert {:ok, %WorkOS.Organizations.Organization{id: id, external_id: external_id}} =
+               WorkOS.Organizations.update_organization(
+                 opts |> Keyword.get(:organization_id),
+                 opts |> Enum.into(%{})
+               )
+
+      refute is_nil(id)
+      assert external_id == "ext_org_456"
     end
   end
 end


### PR DESCRIPTION
Add `external_id` parameter support to create and update operations:
- `WorkOS.Organizations.create_organization/1,2` — accepts `:external_id` in opts
- `WorkOS.Organizations.update_organization/2,3` — accepts `:external_id` in opts

This is a follow-up to #83 which added `external_id` to the structs and added lookup-by-external-id endpoints. With this PR, the SDK fully supports the `external_id` field across all CRUD operations for Organizations.dd