### PR TITLE
Add DX as Codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# DX Team
+* @workos/dx


### PR DESCRIPTION
## Summary

- Adds `@workos/dx` team as code owners for the repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)