### PR TITLE
fix: set canonical User-Agent header format

### DIFF
--- a/lib/workos/client/tesla_client.ex
+++ b/lib/workos/client/tesla_client.ex
@@ -25,7 +25,15 @@ defmodule WorkOS.Client.TeslaClient do
       {Tesla.Middleware.BaseUrl, client.base_url},
       Tesla.Middleware.PathParams,
       Tesla.Middleware.JSON,
-      {Tesla.Middleware.Headers, [{"Authorization", "Bearer #{access_token}"}]}
+      {Tesla.Middleware.Headers,
+       [
+         {"Authorization", "Bearer #{access_token}"},
+         {"User-Agent", user_agent()}
+       ]}
     ])
+  end
+
+  defp user_agent do
+    "workos-elixir/#{Application.spec(:workos, :vsn)}"
   end
 end


### PR DESCRIPTION
## Summary

The Tesla middleware was sending no `User-Agent` header on outgoing requests. This adds one in the canonical WorkOS SDK format: `workos-elixir/{VERSION}`, with the version pulled from the application spec.

## Test plan

- [x] Manual verification: `Application.spec(:workos, :vsn)` returns the charlist version (e.g. `~c"1.2.1"`), and Elixir's `String.Chars.List` implementation converts charlists to a binary on `#{}` interpolation, so the resulting header value is `workos-elixir/1.2.1`.
- [ ] Confirm User-Agent on a real outgoing request

🤖 Generated with [Claude Code](https://claude.com/claude-code)