### PR TITLE
fix: include custom_attributes on SSO Profile struct

### DIFF
--- a/lib/workos/sso/profile.ex
+++ b/lib/workos/sso/profile.ex
@@ -15,7 +15,8 @@ defmodule WorkOS.SSO.Profile do
           first_name: String.t() | nil,
           last_name: String.t() | nil,
           groups: [String.t()] | nil,
-          raw_attributes: %{String.t() => any()} | nil
+          raw_attributes: %{String.t() => any()} | nil,
+          custom_attributes: %{String.t() => any()} | nil
         }
 
   @enforce_keys [:id, :idp_id, :connection_id, :connection_type, :email]
@@ -29,7 +30,8 @@ defmodule WorkOS.SSO.Profile do
     :first_name,
     :last_name,
     :groups,
-    :raw_attributes
+    :raw_attributes,
+    :custom_attributes
   ]
 
   @impl true
@@ -45,7 +47,8 @@ defmodule WorkOS.SSO.Profile do
       first_name: map["first_name"],
       last_name: map["last_name"],
       groups: map["groups"],
-      raw_attributes: map["raw_attributes"]
+      raw_attributes: map["raw_attributes"],
+      custom_attributes: map["custom_attributes"]
     }
   end
 end

--- a/test/support/sso_client_mock.ex
+++ b/test/support/sso_client_mock.ex
@@ -42,6 +42,9 @@ defmodule WorkOS.SSO.ClientMock do
             "first_name" => "foo",
             "last_name" => "bar",
             "groups" => groups
+          },
+          "custom_attributes" => %{
+            "sid" => "S-1-5-21-1004336348-1177238915-682003330-512"
           }
         }
       }
@@ -74,6 +77,9 @@ defmodule WorkOS.SSO.ClientMock do
           "email" => "foo@test.com",
           "first_name" => "foo",
           "last_name" => "bar"
+        },
+        "custom_attributes" => %{
+          "sid" => "S-1-5-21-1004336348-1177238915-682003330-512"
         }
       }
 

--- a/test/workos/sso_test.exs
+++ b/test/workos/sso_test.exs
@@ -145,6 +145,19 @@ defmodule WorkOS.SSOTest do
       refute is_nil(access_token)
       refute is_nil(profile)
     end
+
+    test "casts custom_attributes from the profile response", context do
+      opts = [code: "authorization_code"]
+
+      context |> ClientMock.get_profile_and_token(assert_fields: opts)
+
+      assert {:ok, %WorkOS.SSO.ProfileAndToken{profile: profile}} =
+               WorkOS.SSO.get_profile_and_token(opts |> Keyword.get(:code))
+
+      assert profile.custom_attributes == %{
+               "sid" => "S-1-5-21-1004336348-1177238915-682003330-512"
+             }
+    end
   end
 
   describe "get_profile" do
@@ -157,6 +170,17 @@ defmodule WorkOS.SSOTest do
                WorkOS.SSO.get_profile(opts |> Keyword.get(:access_token))
 
       refute is_nil(id)
+    end
+
+    test "casts custom_attributes from the profile response", context do
+      opts = [access_token: "access_token"]
+
+      context |> ClientMock.get_profile(assert_fields: opts)
+
+      assert {:ok, %WorkOS.SSO.Profile{custom_attributes: custom_attributes}} =
+               WorkOS.SSO.get_profile(opts |> Keyword.get(:access_token))
+
+      assert custom_attributes == %{"sid" => "S-1-5-21-1004336348-1177238915-682003330-512"}
     end
   end
 


### PR DESCRIPTION
## Summary

`WorkOS.SSO.Profile.cast/1` silently drops the `custom_attributes` field returned by `POST /sso/token`, so callers cannot read custom attributes configured on a connection in the WorkOS Dashboard.

This is the documented migration path away from `raw_attributes` ([deprecated 2026-04-15](https://workos.com/docs/sso/attributes)), and `custom_attributes` is listed as a top-level field on the [Profile object](https://workos.com/docs/reference/sso/profile). Without this field on the struct, applications relying on IdP-issued claims (e.g. the `sid` claim used for front-channel single logout) cannot complete the migration and remain broken after the deprecation date.

## Changes

- Add `:custom_attributes` to `WorkOS.SSO.Profile`'s `@type`, `defstruct`, and `cast/1`, immediately after `:raw_attributes`.
- Field is optional (not in `@enforce_keys`, type `| nil`) since the API omits it for connections without custom attributes configured.
- Mirrors the existing handling in `WorkOS.DirectorySync.Directory.User`.

## Tests

- Extended both `get_profile_and_token` and `get_profile` mock fixtures to include a `custom_attributes` payload.
- Added one round-trip test in each `describe` block asserting the field is cast onto the struct.
- `mix test` and `mix format --check-formatted` clean.